### PR TITLE
Updated schedule to Python/Shell/Git order

### DIFF
--- a/_includes/sc/schedule.html
+++ b/_includes/sc/schedule.html
@@ -1,27 +1,31 @@
 <div class="row">
   <div class="col-md-6">
-    <h3>Day 1</h3>
+    <h3>Saturday, January 25, 2020</h3>
     <table class="table table-striped">
       <tr> <td>Before</td> <td><a href="{{ site.swc_pre_survey }}{{ site.github.project_title }}">Pre-workshop survey</a> </td> </tr>
-      <tr> <td>10:30</td>  <td>Intro to Programming in Python</td> </tr>
-      <tr> <td>11:30</td>  <td>Morning break</td> </tr>
+      <tr> <td>10:00</td>  <td><a href="https://swcarpentry.github.io/python-novice-inflammation/">Programming in Python</a></td> </tr>
+      <tr> <td>11:15</td>  <td>Morning break</td> </tr>
+      <tr> <td>11:30</td>  <td>Programming in Python (cont.)</td> </tr>
       <tr> <td>13:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>14:00</td>  <td>Automating Tasks with the Unix Shell</td> </tr>
-      <tr> <td>15:30</td>  <td>Afternoon break</td> </tr>
-      <tr> <td>17:30</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>14:00</td>  <td>Programming in Python (cont.)</td> </tr>
+      <tr> <td>15:45</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>16:00</td>  <td>Programming in Python (cont.)</td> </tr>
+      <tr> <td>17:45</td>  <td>Wrap-up</td> </tr>
       <tr> <td>18:00</td>  <td>END</td> </tr>
     </table>
   </div>
   <div class="col-md-6">
-    <h3>Day 2</h3>
+    <h3>Sunday, January 26, 2020</h3>
     <table class="table table-striped">
-      <tr> <td>10:30</td>  <td>Version Control with Git</td> </tr>
-      <tr> <td>11:30</td>  <td>Morning break</td> </tr>
+      <tr> <td>10:00</td>  <td><a href="https://swcarpentry.github.io/shell-novice/">Automating Tasks with the Unix Shell</a></td> </tr>
+      <tr> <td>11:15</td>  <td>Morning break</td> </tr>
+      <tr> <td>11:30</td>  <td>Automating Tasks with the Unix Shell (cont.)</td> </tr>
       <tr> <td>13:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>14:00</td>  <td>Reproducible Data Analysis in Python</td> </tr>
-      <tr> <td>15:30</td>  <td>Afternoon break</td> </tr>
-      <tr> <td>17:00</td>  <td>Wrap-up</td> </tr>
-      <tr> <td>17:30</td>  <td><a href="{{ site.swc_post_survey }}{{ site.github.project_title }}" target="_blank">Post-workshop Survey</a></td> </tr>
+      <tr> <td>14:00</td>  <td><a href="https://swcarpentry.github.io/git-novice/">Version Control with Git</a></td> </tr>
+      <tr> <td>15:45</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>16:00</td>  <td>Version Control with Git (cont.)</td> </tr>
+      <tr> <td>17:30</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>17:45</td>  <td><a href="{{ site.swc_post_survey }}{{ site.github.project_title }}" target="_blank">Post-workshop Survey</a></td> </tr>
       <tr> <td>18:00</td>  <td>END</td> </tr>
     </table>
   </div>


### PR DESCRIPTION
This PR updates the schedule to reflect the proposed order of:
 - Day 1: Python
 - Day 2, morning: Shell
 - Day 3, afternoon: Git