### PR TITLE
Replaced Google Doc with Carpentries Etherpad as collaborative notes

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ enddate: 2020-01-26        # machine-readable end date for the workshop in YYYY-
 instructor: ["Gaurav Vaidya","Saber Soleymani"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: ["Nicolas Frazee", "TBD"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 email: ["ncf0003@mix.wvu.edu"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
-collaborative_notes: http://pad.carpentries.org/2020-01-25-wvu # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document
+collaborative_notes: https://pad.carpentries.org/2020-01-25-wvu # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document
 eventbrite:   80875648241        # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
 ---
 

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ enddate: 2020-01-26        # machine-readable end date for the workshop in YYYY-
 instructor: ["Gaurav Vaidya","Saber Soleymani"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: ["Nicolas Frazee", "TBD"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 email: ["ncf0003@mix.wvu.edu"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
-collaborative_notes:    https://docs.google.com/document/d/1M0guByk62Jotvh6vYA7t77GhOkuP2HsId16aWZePSNo/edit?usp=sharing       # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document
+collaborative_notes: http://pad.carpentries.org/2020-01-25-wvu # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document
 eventbrite:   80875648241        # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
 ---
 


### PR DESCRIPTION
@ncf0003 Would it be okay if we used the Carpentries Etherpad instead of a Google Doc for collaborative notes? I think it would be easier to ensure that this remains accessible long into the future, while a Google Doc would be tied to a particular user account. What do you think?